### PR TITLE
Allow blocks inside blockquotes

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,7 +10,7 @@ module.exports = {
   ],
   globals: {
     'ts-jest': {
-      tsConfig: 'tsconfig.test.json',
+      tsConfig: '<rootDir>tsconfig.test.json',
     },
   },
   moduleDirectories: ['node_modules'],

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,7 +10,7 @@ module.exports = {
   ],
   globals: {
     'ts-jest': {
-      tsConfig: '<rootDir>tsconfig.test.json',
+      tsConfig: 'tsconfig.test.json',
     },
   },
   moduleDirectories: ['node_modules'],

--- a/packages/slate-plugins/src/elements/blockquote/defaults.ts
+++ b/packages/slate-plugins/src/elements/blockquote/defaults.ts
@@ -1,10 +1,14 @@
+import { DEFAULTS_PARAGRAPH } from '../paragraph';
 import { BlockquoteElement } from './components/BlockquoteElement';
-import { BlockquoteKeyOption, BlockquotePluginOptionsValues } from './types';
+import {
+  BlockquoteDefaultsOptions,
+  BlockquotePluginOptionsValues,
+} from './types';
 
 export const ELEMENT_BLOCKQUOTE = 'blockquote';
 
 export const DEFAULTS_BLOCKQUOTE: Record<
-  BlockquoteKeyOption,
+  BlockquoteDefaultsOptions,
   BlockquotePluginOptionsValues
 > = {
   blockquote: {
@@ -16,4 +20,5 @@ export const DEFAULTS_BLOCKQUOTE: Record<
       as: 'blockquote',
     },
   },
+  ...DEFAULTS_PARAGRAPH,
 };

--- a/packages/slate-plugins/src/elements/blockquote/index.ts
+++ b/packages/slate-plugins/src/elements/blockquote/index.ts
@@ -4,3 +4,5 @@ export * from './defaults';
 export * from './deserializeBlockquote';
 export * from './renderElementBlockquote';
 export * from './types';
+export * from './withBlockquote';
+export * from './normalizers';

--- a/packages/slate-plugins/src/elements/blockquote/normalizers/index.ts
+++ b/packages/slate-plugins/src/elements/blockquote/normalizers/index.ts
@@ -1,0 +1,1 @@
+export * from './normalizeBlockquote';

--- a/packages/slate-plugins/src/elements/blockquote/normalizers/normalizeBlockquote.ts
+++ b/packages/slate-plugins/src/elements/blockquote/normalizers/normalizeBlockquote.ts
@@ -5,7 +5,7 @@ import { DEFAULTS_BLOCKQUOTE, ELEMENT_BLOCKQUOTE } from '../defaults';
 import { BlockquoteOptions } from '../types';
 
 /**
- * If the blockquote has no child: insert an empty paragraph.
+ * Force all blockquote children to be a block, if not, wrap them in a paragraph
  */
 export const normalizeBlockquote = (
   editor: Editor,

--- a/packages/slate-plugins/src/elements/blockquote/normalizers/normalizeBlockquote.ts
+++ b/packages/slate-plugins/src/elements/blockquote/normalizers/normalizeBlockquote.ts
@@ -1,0 +1,37 @@
+import { Editor, Node, NodeEntry, Text, Transforms } from 'slate';
+import { match } from '../../../common/utils';
+import { setDefaults } from '../../../common/utils/setDefaults';
+import { DEFAULTS_BLOCKQUOTE, ELEMENT_BLOCKQUOTE } from '../defaults';
+import { BlockquoteOptions } from '../types';
+
+/**
+ * If the blockquote has no child: insert an empty paragraph.
+ */
+export const normalizeBlockquote = (
+  editor: Editor,
+  options: BlockquoteOptions
+) => {
+  const { normalizeNode } = editor;
+
+  const { p } = setDefaults(options, DEFAULTS_BLOCKQUOTE);
+
+  return (entry: NodeEntry) => {
+    const [node, path] = entry;
+
+    // Ensure all direct children of a blockquote is a block, if not, wrap them in a paragraph
+    if (match(node, { type: ELEMENT_BLOCKQUOTE })) {
+      for (const [child, childPath] of Node.children(editor, path)) {
+        if (Text.isText(child) || editor.isInline(child)) {
+          Transforms.wrapNodes(
+            editor,
+            { type: p.type, children: [] },
+            { at: childPath }
+          );
+          return;
+        }
+      }
+    }
+
+    normalizeNode(entry);
+  };
+};

--- a/packages/slate-plugins/src/elements/blockquote/types.ts
+++ b/packages/slate-plugins/src/elements/blockquote/types.ts
@@ -79,3 +79,5 @@ export interface BlockquoteElementStyleProps {
 
   // Insert BlockquoteElement style props below
 }
+
+export interface BlockquoteOptions extends BlockquotePluginOptions<'type'> {}

--- a/packages/slate-plugins/src/elements/blockquote/types.ts
+++ b/packages/slate-plugins/src/elements/blockquote/types.ts
@@ -40,6 +40,7 @@ export interface BlockquoteElementProps
 }
 
 export type BlockquoteKeyOption = 'blockquote';
+export type BlockquoteDefaultsOptions = 'blockquote' | 'p';
 
 // Plugin options
 export type BlockquotePluginOptionsValues = RenderNodeOptions &

--- a/packages/slate-plugins/src/elements/blockquote/withBlockquote.spec.tsx
+++ b/packages/slate-plugins/src/elements/blockquote/withBlockquote.spec.tsx
@@ -1,0 +1,35 @@
+/** @jsx jsx */
+
+import { Editor } from 'slate';
+import { withReact } from 'slate-react';
+import { jsx } from '../../__test-utils__/jsx';
+import { pipe } from '../../common/utils';
+import { withBlockquote } from './index';
+
+describe('normalizeBlockquote', () => {
+  describe('when inserting a text in an empty blockquote', () => {
+    it('should wrap the text in a paragraph', () => {
+      const input = ((
+        <editor>
+          <hblockquote>
+            <cursor />
+          </hblockquote>
+        </editor>
+      ) as any) as Editor;
+
+      const expected = ((
+        <editor>
+          <hblockquote>
+            <hp>o</hp>
+          </hblockquote>
+        </editor>
+      ) as any) as Editor;
+
+      const editor = pipe(input, withReact, withBlockquote());
+
+      editor.insertText('o');
+
+      expect(editor.children).toEqual(expected.children);
+    });
+  });
+});

--- a/packages/slate-plugins/src/elements/blockquote/withBlockquote.ts
+++ b/packages/slate-plugins/src/elements/blockquote/withBlockquote.ts
@@ -1,0 +1,13 @@
+import { ReactEditor } from 'slate-react';
+import { normalizeBlockquote } from './normalizers';
+import { BlockquoteOptions } from './types';
+
+export const withBlockquote = (options: BlockquoteOptions = {}) => <
+  T extends ReactEditor
+>(
+  editor: T
+) => {
+  editor.normalizeNode = normalizeBlockquote(editor, options);
+
+  return editor;
+};

--- a/stories/config/initialValues.ts
+++ b/stories/config/initialValues.ts
@@ -769,7 +769,16 @@ export const initialValueBasicElements: SlateDocument = [
       },
       {
         type: options.blockquote.type,
-        children: [{ text: 'Blockquote' }],
+        children: [
+          {
+            type: options.p.type,
+            children: [
+              {
+                text: 'Blockquote',
+              },
+            ],
+          },
+        ],
       },
       {
         type: options.code_block.type,

--- a/stories/elements/basic-elements.stories.tsx
+++ b/stories/elements/basic-elements.stories.tsx
@@ -52,7 +52,7 @@ const withPlugins = [withReact, withHistory, withBlockquote(options)] as const;
 export const Example = () => {
   const plugins: SlatePlugin[] = [];
   if (boolean('ParagraphPlugin', true)) plugins.push(ParagraphPlugin(options));
-  if (boolean('BlockquotePlugin', true)) {
+  if (boolean('BlockquotePlugin', true))
     plugins.push(BlockquotePlugin(options));
   if (boolean('CodePlugin', true)) plugins.push(CodeBlockPlugin(options));
   if (boolean('HeadingPlugin', true)) plugins.push(HeadingPlugin(options));

--- a/stories/elements/basic-elements.stories.tsx
+++ b/stories/elements/basic-elements.stories.tsx
@@ -25,6 +25,7 @@ import {
   SlatePlugin,
   SoftBreakPlugin,
   ToolbarElement,
+  withBlockquote,
 } from '@udecode/slate-plugins';
 import { createEditor } from 'slate';
 import { withHistory } from 'slate-history';
@@ -46,12 +47,12 @@ export default {
   },
 };
 
-const withPlugins = [withReact, withHistory] as const;
+const withPlugins = [withReact, withHistory, withBlockquote(options)] as const;
 
 export const Example = () => {
   const plugins: SlatePlugin[] = [];
   if (boolean('ParagraphPlugin', true)) plugins.push(ParagraphPlugin(options));
-  if (boolean('BlockquotePlugin', true))
+  if (boolean('BlockquotePlugin', true)) {
     plugins.push(BlockquotePlugin(options));
   if (boolean('CodePlugin', true)) plugins.push(CodeBlockPlugin(options));
   if (boolean('HeadingPlugin', true)) plugins.push(HeadingPlugin(options));

--- a/stories/examples/dnd.stories.tsx
+++ b/stories/examples/dnd.stories.tsx
@@ -8,9 +8,9 @@ import { CodeBlock } from '@styled-icons/boxicons-regular/CodeBlock';
 import { Subscript, Superscript } from '@styled-icons/foundation';
 import {
   FormatAlignCenter,
+  FormatAlignJustify,
   FormatAlignLeft,
   FormatAlignRight,
-  FormatAlignJustify,
   FormatBold,
   FormatItalic,
   FormatListBulleted,
@@ -78,6 +78,7 @@ import {
   UnderlinePlugin,
   useMention,
   withAutoformat,
+  withBlockquote,
   withDeserializeHTML,
   withImageUpload,
   withInlineVoid,
@@ -295,6 +296,7 @@ export const Example = () => {
     withTable(options),
     withLink(),
     withList(options),
+    withBlockquote(options),
     withDeserializeHTML({ plugins }),
     withMarks(),
     withImageUpload(),

--- a/stories/examples/playground.stories.tsx
+++ b/stories/examples/playground.stories.tsx
@@ -6,9 +6,9 @@ import { CodeBlock } from '@styled-icons/boxicons-regular/CodeBlock';
 import { Subscript, Superscript } from '@styled-icons/foundation';
 import {
   FormatAlignCenter,
+  FormatAlignJustify,
   FormatAlignLeft,
   FormatAlignRight,
-  FormatAlignJustify,
   FormatBold,
   FormatItalic,
   FormatListBulleted,
@@ -75,6 +75,7 @@ import {
   UnderlinePlugin,
   useMention,
   withAutoformat,
+  withBlockquote,
   withDeserializeHTML,
   withImageUpload,
   withInlineVoid,
@@ -82,9 +83,9 @@ import {
   withList,
   withMarks,
   withNormalizeTypes,
+  withSelectOnBackspace,
   withTable,
   withTrailingNode,
-  withSelectOnBackspace,
 } from '@udecode/slate-plugins';
 import { createEditor, Node } from 'slate';
 import { withHistory } from 'slate-history';
@@ -210,6 +211,7 @@ export const Plugins = () => {
     withTable(options),
     withLink(),
     withList(options),
+    withBlockquote(options),
     withDeserializeHTML({ plugins }),
     withMarks(),
     withImageUpload(),


### PR DESCRIPTION
This PR changes the behavior of blockquote blocks. They were previously only accepting text elements as children but now support other elements such as list, images, code block.

It can be tested on this storybook https://gaeldestrem.github.io/slate-plugins-storybook/index.html?path=/story/examples-playground--plugins

## GIF

![IMAGE ALT TEXT HERE](http://g.recordit.co/t8PSjmxU7V.gif)



## Checklist

- [x] The new code matches the existing patterns and styles.
- [x] The stories still work (run `yarn storybook`).
- [x] The stories are updated when relevant: `stories` for plugins, `knobs` for options.
- [x] Lint and tests status is Ok



